### PR TITLE
made linux/zf_host_parse_num() more strict so it will fail when conve…

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -188,8 +188,9 @@ void zf_host_trace(const char *fmt, va_list va)
 zf_cell zf_host_parse_num(const char *buf)
 {
 	zf_cell v;
-	int r = sscanf(buf, "%f", &v);
-	if(r == 0) {
+	int n = 0;
+	int r = sscanf(buf, "%f%n", &v, &n);
+	if(r == 0 || buf[n] != '\0') {
 		zf_abort(ZF_ABORT_NOT_A_WORD);
 	}
 	return v;


### PR DESCRIPTION
In the current zf_host_parse_num implementation  have an issue if you want to use word which start with digit.
For example if you try to write on the console 2dup it isn't interpreted as word 2dup - it is interpreted as value 2 and it is added to dstack:
    2dup
    .
    2
With this patch naow result is as expected (2dup word isn't defined in dictionary):
    2dup
    stdin:1: not a word

 